### PR TITLE
Improve usability and filename handling

### DIFF
--- a/splitpdf
+++ b/splitpdf
@@ -26,13 +26,18 @@ function padnum {
     echo $n
 }
 
-if [[ $# -ne 1 || "$@" == "-h" || "$@" == "--help" ]] ; then
-    echo "Usage: splitpdf <infile.pdf>."
-    echo ""
-    echo "Splits original file into single page files named"
-    echo "as <infile_p#.pdf> where # is the page number."
-    exit 1
-fi
+# Check for help
+for arg in "$@"; do
+	case "$arg" in
+		-h|--help)
+			echo "Usage: splitpdf <infile.pdf>..."
+			echo ""
+			echo "Splits original file into single page files named"
+			echo "as <infile_page#.pdf> where # is the page number."
+			exit 0
+			;;
+	esac
+done
 
 infile="$1"
 if [[ ! -f "$infile" ]] ; then

--- a/splitpdf
+++ b/splitpdf
@@ -44,6 +44,12 @@ firstpage=1
 lastpage=$(numpages $1)
 basename=$(basename "$infile" .pdf)
 
+# Check if PDF has only one page
+if [ "$lastpage" -eq 1 ]; then
+    echo "PDF file contains only one page"
+    exit 0
+fi
+
 for((i=$firstpage;i<=lastpage;i=i+1)); do
     printf "Extracting Page $i"'\r';
     gs -sDEVICE=pdfwrite -dNOPAUSE -dBATCH -dSAFER \

--- a/splitpdf
+++ b/splitpdf
@@ -42,20 +42,22 @@ fi
 
 firstpage=1
 lastpage=$(numpages $1)
-basename=$(basename "$infile" .pdf)
-
 # Check if PDF has only one page
 if [ "$lastpage" -eq 1 ]; then
     echo "PDF file contains only one page"
     exit 0
 fi
+base="${infile##*/}"
+base="${base%.[Pp][Dd][Ff]}"
+dir="$(dirname "$infile")"
+ext="${infile##*.}"
 
 for((i=$firstpage;i<=lastpage;i=i+1)); do
     printf "Extracting Page $i"'\r';
     gs -sDEVICE=pdfwrite -dNOPAUSE -dBATCH -dSAFER \
        -dFirstPage=$i \
        -dLastPage=$i \
-       -sOutputFile="${basename}_page$(padnum $i $lastpage).pdf" \
+       -sOutputFile="${dir}/${base}_page$(padnum $i $lastpage).${ext}" \
        "$infile" &> /dev/null
     if [[ $? -ne 0 ]] ; then
         echo "Error extracting page $i"

--- a/splitpdf
+++ b/splitpdf
@@ -49,7 +49,7 @@ for((i=$firstpage;i<=lastpage;i=i+1)); do
     gs -sDEVICE=pdfwrite -dNOPAUSE -dBATCH -dSAFER \
        -dFirstPage=$i \
        -dLastPage=$i \
-       -sOutputFile="${basename}_p$(padnum $i $lastpage).pdf" \
+       -sOutputFile="${basename}_page$(padnum $i $lastpage).pdf" \
        "$infile" &> /dev/null
     if [[ $? -ne 0 ]] ; then
         echo "Error extracting page $i"

--- a/splitpdf
+++ b/splitpdf
@@ -4,70 +4,74 @@
 
 # Returns number of pages in a PDF file
 function numpages {
-    filename="$1"
-    gs -q -dNOSAFER -dNODISPLAY -c "($filename) (r) file runpdfbegin pdfpagecount = quit"
+        filename="$1"
+        gs -q -dNOSAFER -dNODISPLAY -c "($filename) (r) file runpdfbegin pdfpagecount = quit"
 }
 
 # Returns the number of digits in an integer
 function ndigits {
-    num="$1"
-    echo "$num" | awk '{print(int(log($0)/log(10))+1);}'
+        num="$1"
+        echo "$num" | awk '{print(int(log($0)/log(10))+1);}'
 }
 
 # Pads number according to the number of 0's needed.
 function padnum {
-    n=$1
-    maxn=$2
-    ndigits=$(ndigits $n)
-    maxndigits=$(ndigits $maxn)
-    for((i=1;i<=(maxndigits-ndigits);i=i+1)); do
-        printf 0
-    done
-    echo $n
+        n=$1
+        maxn=$2
+        ndigits=$(ndigits $n)
+        maxndigits=$(ndigits $maxn)
+        for((i=1;i<=(maxndigits-ndigits);i=i+1)); do
+        	printf 0
+        done
+        echo $n
 }
 
-# Check for help
-for arg in "$@"; do
-	case "$arg" in
-		-h|--help)
-			echo "Usage: splitpdf <infile.pdf>..."
-			echo ""
-			echo "Splits original file into single page files named"
-			echo "as <infile_page#.pdf> where # is the page number."
-			exit 0
-			;;
-	esac
-done
+# Main loop over PDF files
+function main {
+	local infile="$1"
+	echo "Processing file '$infile'."
+	if [[ ! -f "$infile" ]] ; then
+		echo "Error: file $infile does not exist."
+		exit 1
+	fi
 
-infile="$1"
-if [[ ! -f "$infile" ]] ; then
-    echo "Error: file $infile does not exist"
-    exit 1
+	firstpage=1
+	local lastpage=$(numpages "$infile")
+	# Check if PDF has only one page
+	if [ "$lastpage" -eq "$firstpage" ]; then
+		echo "Info: file '$infile' contains only one page."
+		return 0
+	fi
+	local base="${infile##*/}"
+	local base="${base%.[Pp][Dd][Ff]}"
+	local dir="$(dirname "$infile")"
+	local ext="${infile##*.}"
+
+	for((i=$firstpage;i<=lastpage;i=i+1)); do
+	        printf "Extracting Page $i"'\r';
+	        gs -sDEVICE=pdfwrite -dNOPAUSE -dBATCH -dSAFER \
+	           -dFirstPage=$i \
+	           -dLastPage=$i \
+	           -sOutputFile="${dir}/${base}_page$(padnum $i $lastpage).${ext}" \
+	           "$infile" &> /dev/null
+	        if [[ $? -ne 0 ]] ; then
+	    		echo "Error extracting page $i."
+	        fi
+	done
+	# Clear line command
+	printf '\033[K'
+	echo "done"
+}
+
+# main execution
+if [[ "$@" == "-h" || "$@" == "--help" ]] ; then
+        echo "Usage: splitpdf <infile.pdf>."
+        echo ""
+        echo "Splits original file into single page files named"
+        echo "as <infile_p#.pdf> where # is the page number."
+        exit 1
 fi
 
-firstpage=1
-lastpage=$(numpages $1)
-# Check if PDF has only one page
-if [ "$lastpage" -eq 1 ]; then
-    echo "PDF file contains only one page"
-    exit 0
-fi
-base="${infile##*/}"
-base="${base%.[Pp][Dd][Ff]}"
-dir="$(dirname "$infile")"
-ext="${infile##*.}"
-
-for((i=$firstpage;i<=lastpage;i=i+1)); do
-    printf "Extracting Page $i"'\r';
-    gs -sDEVICE=pdfwrite -dNOPAUSE -dBATCH -dSAFER \
-       -dFirstPage=$i \
-       -dLastPage=$i \
-       -sOutputFile="${dir}/${base}_page$(padnum $i $lastpage).${ext}" \
-       "$infile" &> /dev/null
-    if [[ $? -ne 0 ]] ; then
-        echo "Error extracting page $i"
-    fi
+for file in "$@"; do
+	main "$file"
 done
-# Clear line command
-printf '\033[K'
-echo "done"

--- a/splitpdf
+++ b/splitpdf
@@ -42,9 +42,6 @@ function main {
                 echo "Info: file '$infile' contains only one page. Skipping..."
 		return 0
 	fi
-	local base="${infile##*/}"
-	local base="${base%.[Pp][Dd][Ff]}"
-	local dir="$(dirname "$infile")"
 	local ext="${infile##*.}"
 
 	for((i=$firstpage;i<=lastpage;i=i+1)); do
@@ -52,7 +49,7 @@ function main {
 	        gs -sDEVICE=pdfwrite -dNOPAUSE -dBATCH -dSAFER \
 	           -dFirstPage=$i \
 	           -dLastPage=$i \
-	           -sOutputFile="${dir}/${base}_page$(padnum $i $lastpage).${ext}" \
+                   -sOutputFile="${infile%.*}"_page"$(padnum $i $lastpage).${ext}" \
 	           "$infile" &> /dev/null
 	        if [[ $? -ne 0 ]] ; then
                         echo "File $infile: Error extracting page $i."

--- a/splitpdf
+++ b/splitpdf
@@ -1,6 +1,6 @@
 #!/bin/bash
-# This script splits a PDF file into its constituent pages, one file
-# per page.
+# This script splits one or more PDF files into their constituent pages,
+# one file per page.
 
 # Returns number of pages in a PDF file
 function numpages {
@@ -26,20 +26,20 @@ function padnum {
         echo $n
 }
 
-# Main loop over PDF files
+# Main loop for each PDF file
 function main {
 	local infile="$1"
 	echo "Processing file '$infile'."
 	if [[ ! -f "$infile" ]] ; then
 		echo "Error: file $infile does not exist."
-		exit 1
+		return 1
 	fi
 
-	firstpage=1
+	local firstpage=1
 	local lastpage=$(numpages "$infile")
 	# Check if PDF has only one page
-	if [ "$lastpage" -eq "$firstpage" ]; then
-		echo "Info: file '$infile' contains only one page."
+	if [ "$lastpage" -eq 1 ]; then
+                echo "Info: file '$infile' contains only one page. Skipping..."
 		return 0
 	fi
 	local base="${infile##*/}"
@@ -48,30 +48,35 @@ function main {
 	local ext="${infile##*.}"
 
 	for((i=$firstpage;i<=lastpage;i=i+1)); do
-	        printf "Extracting Page $i"'\r';
+	        printf "File $infile: Extracting Page $i"'\r';
 	        gs -sDEVICE=pdfwrite -dNOPAUSE -dBATCH -dSAFER \
 	           -dFirstPage=$i \
 	           -dLastPage=$i \
 	           -sOutputFile="${dir}/${base}_page$(padnum $i $lastpage).${ext}" \
 	           "$infile" &> /dev/null
 	        if [[ $? -ne 0 ]] ; then
-	    		echo "Error extracting page $i."
+                        echo "File $infile: Error extracting page $i."
 	        fi
 	done
 	# Clear line command
-	printf '\033[K'
-	echo "done"
+	printf '\033[K\n'
+	echo "File $infile: done"
 }
 
-# main execution
-if [[ "$@" == "-h" || "$@" == "--help" ]] ; then
-        echo "Usage: splitpdf <infile.pdf>."
-        echo ""
-        echo "Splits original file into single page files named"
-        echo "as <infile_p#.pdf> where # is the page number."
-        exit 1
-fi
+# Check for help
+for arg in "$@"; do
+	case "$arg" in
+		-h|--help)
+			echo "Usage: splitpdf <infile.pdf>..."
+			echo ""
+			echo "Splits original file into single page files named"
+			echo "as <infile_page#.pdf> where # is the page number."
+			exit 0
+			;;
+	esac
+done
 
+# Call main function for all passed filenames
 for file in "$@"; do
-	main "$file"
+        main "$file"
 done

--- a/splitpdf
+++ b/splitpdf
@@ -29,11 +29,11 @@ function padnum {
 # Main loop for each PDF file
 function main {
 	local infile="$1"
-	echo "Processing file '$infile'."
 	if [[ ! -f "$infile" ]] ; then
 		echo "Error: file $infile does not exist."
 		return 1
 	fi
+	echo "Processing file '$infile'."
 
 	local firstpage=1
 	local lastpage=$(numpages "$infile")


### PR DESCRIPTION
This PR includes several improvements to the splitpdf script:

- Support multiple input files for batch processing.
- Fix bugs when handling filenames with spaces.
- Catch the help flag regardless of argument position.
- Allow case-insensitive file extensions and preserve directory in output.
- Add check for single-page files to avoid unnecessary processing.
- Change output file naming for clarity and consistency.

These changes are backward-compatible and aim to make the script more robust and easier to use in common workflows.

Feedback and suggestions welcome!